### PR TITLE
Quickfix for latte strict parsing mode

### DIFF
--- a/src/FormRenderer/TemplateRenderer.php
+++ b/src/FormRenderer/TemplateRenderer.php
@@ -53,6 +53,7 @@ class TemplateRenderer implements Nette\Forms\FormRenderer
         $template->setFile(self::TEMPLATE_FILE);
 
         $latte = $template->getLatte();
+        $latte->addProvider('formRendererImports', $this->templateImports);
         $latte->addFilter('safeTranslate', $this->safeTranslateFilterFactory->create($form->getTranslator()));
 
         $template->form = $form;

--- a/src/FormRenderer/TemplateRenderer.php
+++ b/src/FormRenderer/TemplateRenderer.php
@@ -53,10 +53,10 @@ class TemplateRenderer implements Nette\Forms\FormRenderer
         $template->setFile(self::TEMPLATE_FILE);
 
         $latte = $template->getLatte();
-        $latte->addProvider('formRendererImports', $this->templateImports);
         $latte->addFilter('safeTranslate', $this->safeTranslateFilterFactory->create($form->getTranslator()));
 
         $template->form = $form;
+        $template->templateImports = $this->templateImports;
 
         return (string) $template;
     }

--- a/src/FormRenderer/templates/form.latte
+++ b/src/FormRenderer/templates/form.latte
@@ -1,4 +1,4 @@
-{foreach $this->global->formRendererImports as $templateFile}
+{foreach $templateImports as $templateFile}
     {import $templateFile}
 {/foreach}
 {include #form, form => $form}

--- a/tests/Bridges/FormRendererDI/FormRendererLatteStrictExtensionTest.phpt
+++ b/tests/Bridges/FormRendererDI/FormRendererLatteStrictExtensionTest.phpt
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types = 1);
+
+namespace NepadaTests\Bridges\FormRendererDI;
+
+use Nepada\FormRenderer;
+use NepadaTests\Environment;
+use NepadaTests\TestCase;
+use Nette;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+
+/**
+ * @testCase
+ */
+class FormRendererLatteStrictExtensionTest extends TestCase
+{
+
+    private Nette\DI\Container $container;
+
+    public function testServices(): void
+    {
+        Assert::type(FormRenderer\Filters\SafeTranslateFilterFactory::class, $this->container->getService('formRenderer.filters.safeTranslateFilterFactory'));
+        Assert::type(FormRenderer\TemplateRendererFactory::class, $this->container->getService('formRenderer.templateRendererFactory'));
+        Assert::type(FormRenderer\TemplateRendererFactory::class, $this->container->getService('formRenderer.defaultRendererFactory'));
+        Assert::type(FormRenderer\Bootstrap3RendererFactory::class, $this->container->getService('formRenderer.bootstrap3RendererFactory'));
+        Assert::type(FormRenderer\Bootstrap4RendererFactory::class, $this->container->getService('formRenderer.bootstrap4RendererFactory'));
+    }
+
+    public function testRendering(): void
+    {
+        $form = new Nette\Forms\Form();
+
+        $defaultRenderer = $this->container->getByType(FormRenderer\TemplateRendererFactory::class)->create();
+        Assert::same("FORM\n\nformLatteStrict.latte,default.latte\n", $defaultRenderer->render($form));
+
+        $bootstrap3Renderer = $this->container->getByType(FormRenderer\Bootstrap3RendererFactory::class)->create();
+        Assert::same("FORM\nhorizontal\nformLatteStrict.latte,bootstrap3.latte\n", $bootstrap3Renderer->render($form));
+
+        $bootstrap4Renderer = $this->container->getByType(FormRenderer\Bootstrap4RendererFactory::class)->create();
+        Assert::same("FORM\nhorizontal\nformLatteStrict.latte,bootstrap4.latte\n", $bootstrap4Renderer->render($form));
+    }
+
+    protected function setUp(): void
+    {
+        $configurator = new Nette\Configurator();
+        $configurator->setTempDirectory(Environment::getTempDir());
+        $configurator->setDebugMode(true);
+        $configurator->addParameters(['fixturesDir' => __DIR__ . '/fixtures']);
+        $configurator->addConfig(__DIR__ . '/fixtures/configLatteStrict.neon');
+        $this->container = $configurator->createContainer();
+    }
+
+}
+
+
+(new FormRendererLatteStrictExtensionTest())->run();

--- a/tests/Bridges/FormRendererDI/fixtures/configLatteStrict.neon
+++ b/tests/Bridges/FormRendererDI/fixtures/configLatteStrict.neon
@@ -1,0 +1,29 @@
+extensions:
+    formRenderer: Nepada\Bridges\FormRendererDI\FormRendererExtension
+
+formRenderer:
+    default:
+        imports:
+            - %fixturesDir%/formLatteStrict.latte
+    bootstrap3:
+        mode: horizontal
+        renderValidState: false
+        imports:
+            - %fixturesDir%/formLatteStrict.latte
+    bootstrap4:
+        mode: horizontal
+        useCustomControls: false
+        useErrorTooltips: false
+        renderValidState: false
+        imports:
+            - %fixturesDir%/formLatteStrict.latte
+
+application:
+    scanDirs: false
+
+di:
+    debugger: false
+
+latte:
+    strictTypes: true
+    strictParsing: true

--- a/tests/Bridges/FormRendererDI/fixtures/form.latte
+++ b/tests/Bridges/FormRendererDI/fixtures/form.latte
@@ -1,5 +1,5 @@
 {block #form}
 FORM
 {ifset $mode}{$mode}{/ifset}
-{foreach $this->global->formRendererImports as $templateFile}{=basename($templateFile)}{sep},{/sep}{/foreach}
+{foreach $templateImports as $templateFile}{=basename($templateFile)}{sep},{/sep}{/foreach}
 {/block}

--- a/tests/Bridges/FormRendererDI/fixtures/form.latte
+++ b/tests/Bridges/FormRendererDI/fixtures/form.latte
@@ -1,5 +1,5 @@
 {block #form}
 FORM
 {ifset $mode}{$mode}{/ifset}
-{foreach $templateImports as $templateFile}{=basename($templateFile)}{sep},{/sep}{/foreach}
+{foreach $this->global->formRendererImports as $templateFile}{=basename($templateFile)}{sep},{/sep}{/foreach}
 {/block}

--- a/tests/Bridges/FormRendererDI/fixtures/formLatteStrict.latte
+++ b/tests/Bridges/FormRendererDI/fixtures/formLatteStrict.latte
@@ -1,0 +1,5 @@
+{block #form}
+FORM
+{ifset $mode}{$mode}{/ifset}
+{foreach $templateImports as $templateFile}{=basename($templateFile)}{sep},{/sep}{/foreach}
+{/block}


### PR DESCRIPTION
Using `$this` is forbidden in Latte's new Strict Parsing mode:

- https://blog.nette.org/en/latte-news-linter-and-strict-mode
- https://forum.nette.org/cs/36053-prosim-o-otestovani-latte-3-0-8

I'm not sure if it's the correct way to do it, but it works :)